### PR TITLE
Add simple search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+sitemap.xml

--- a/complete.css
+++ b/complete.css
@@ -186,3 +186,27 @@ small {
   vertical-align: sub;
 }
 
+#search-results {
+  list-style: none;
+  padding: 8px;
+  line-height: 28px;
+  width: 320px;
+  margin: 0 auto;
+  background-color: #efefef;
+  border: 1px solid #ddd;
+  border-top: 0;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  color: #34495e;
+}
+
+#search-results:empty {
+   display: none;
+}
+
+#search-results li {
+  text-align: left;
+}
+#search-results a {
+  text-decoration: none;
+}

--- a/complete.css
+++ b/complete.css
@@ -142,3 +142,47 @@ small {
 .no-upcase {
   text-transform: none;
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  border: 0;
+}
+
+#search {
+  padding: 2px 8px;
+  /* font-size: 100%; */
+  width: 300px;
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+  border: 1px solid grey;
+  border-right: none;
+  line-height: 24px;
+}
+
+#search-submit {
+  padding: 2px 8px;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  line-height: 24px;
+  color: grey;
+  border-left: none;
+  background-color: transparent;
+  border: 1px solid grey;
+  border-left: none;
+}
+
+#search-submit svg {
+  position: relative;
+  top: 1px;
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+  vertical-align: sub;
+}
+

--- a/index.html
+++ b/index.html
@@ -70,6 +70,28 @@
     <script type="text/javascript">
       var searchIndex = [];
       (function () {
+        document.getElementById('search-submit').addEventListener("click", function (e) {
+          e.preventDefault();
+          e.stopPropagation();
+          if (!searchIndex.length) buildSearchIndex();
+          var searchText = document.getElementById('search').value.toLowerCase();
+          var searchResults = document.getElementById('search-results');
+          searchResults.innerHTML = "";
+
+          for (var i = 0; i < searchIndex.length; i++) {
+            if (searchIndex[i].name === searchText) {
+              var li = document.createElement("li");
+              li.innerHTML = "<em>" + makeMatch(searchIndex[i]) + "</em>";
+              searchResults.insertBefore(li, searchResults.firstChild);
+            } else if (searchIndex[i].name.search(searchText) >= 0) {
+              var li = document.createElement("li");
+              li.innerHTML = makeMatch(searchIndex[i]);
+              searchResults.appendChild(li);
+            }
+          }
+          return true;
+        });
+
         function buildSearchIndex() {
           var xhttp = new XMLHttpRequest();
           xhttp.onreadystatechange = function() {
@@ -87,25 +109,11 @@
           xhttp.send();
         }
 
-        document.getElementById('search-submit').addEventListener("click", function (e) {
-          e.preventDefault();
-          e.stopPropagation();
-          if (!searchIndex.length) buildSearchIndex();
-          var searchText = document.getElementById('search').value.toLowerCase();
-          var searchResults = document.getElementById('search-results');
-          searchResults.innerHTML = "";
-
-          for (var i = 0; i < searchIndex.length; i++) {
-            if (searchIndex[i].name.search(searchText) >= 0) {
-              var li = document.createElement("li");
-              li.innerHTML = "<a href='{{url}}'>{{name}}</a> (<a href='https://hex.pm/packages/{{name}}'>hex</a>)"
-                .replace(/{{name}}/g, searchIndex[i].name)
-                .replace(/{{url}}/g, searchIndex[i].url);
-              searchResults.appendChild(li);
-            }
-          }
-          return true;
-        });
+        function makeMatch(result) {
+          return "<a href='{{url}}'>{{name}}</a> (<a href='https://hex.pm/packages/{{name}}'>hex</a>)"
+                .replace(/{{name}}/g, result.name)
+                .replace(/{{url}}/g, result.url);
+        }
       })();
     </script>
   </body>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@
           --><button type="submit" id="search-submit" tabindex="1"><svg aria-hidden="aria-hidden" version="1.1" viewBox="0 0 1200 1200"><g transform="translate(0, 1200) scale(1, -1)"><path d="M500 1191q100 0 191 -39t156.5 -104.5t104.5 -156.5t39 -191l-1 -2l1 -5q0 -141 -78 -262l275 -274q23 -26 22.5 -44.5t-22.5 -42.5l-59 -58q-26 -20 -46.5 -20t-39.5 20l-275 274q-119 -77 -261 -77l-5 1l-2 -1q-100 0 -191 39t-156.5 104.5t-104.5 156.5t-39 191 t39 191t104.5 156.5t156.5 104.5t191 39zM500 1022q-88 0 -162 -43t-117 -117t-43 -162t43 -162t117 -117t162 -43t162 43t117 117t43 162t-43 162t-117 117t-162 43z"></path></g></svg></button>
         </form>
 
+        <ul id="search-results"></ul>
+
         <p>
           To find documentation sets on HexDocs, you can go to the following URLs:
         </p>
@@ -65,5 +67,46 @@
         </p>
       </div>
     </div>
+    <script type="text/javascript">
+      var searchIndex = [];
+      (function () {
+        function buildSearchIndex() {
+          var xhttp = new XMLHttpRequest();
+          xhttp.onreadystatechange = function() {
+            if (this.readyState == XMLHttpRequest.DONE && this.status == 200) {
+              out=this.responseXML;
+              var iter, locs = this.responseXML.querySelectorAll("loc").values();
+              while (iter = locs.next()) {
+                if (iter.done) break;
+                var loc = iter.value.textContent;
+                searchIndex.push({ name: loc.match("/(\\w+)/$")[1].toLowerCase(), url: loc });
+              }
+            }
+          };
+          xhttp.open("GET", "/sitemap.xml", false);
+          xhttp.send();
+        }
+
+        document.getElementById('search-submit').addEventListener("click", function (e) {
+          e.preventDefault();
+          e.stopPropagation();
+          if (!searchIndex.length) buildSearchIndex();
+          var searchText = document.getElementById('search').value.toLowerCase();
+          var searchResults = document.getElementById('search-results');
+          searchResults.innerHTML = "";
+
+          for (var i = 0; i < searchIndex.length; i++) {
+            if (searchIndex[i].name.search(searchText) >= 0) {
+              var li = document.createElement("li");
+              li.innerHTML = "<a href='{{url}}'>{{name}}</a> (<a href='https://hex.pm/packages/{{name}}'>hex</a>)"
+                .replace(/{{name}}/g, searchIndex[i].name)
+                .replace(/{{url}}/g, searchIndex[i].url);
+              searchResults.appendChild(li);
+            }
+          }
+          return true;
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,12 @@
 
         <h3>Finding documentation</h3>
 
+        <form autocomplete="off">
+          <input type="search" autofocus="" placeholder="Find packages" name="search" id="search" value="" tabindex="1"><!--
+          --><label class="sr-only" for="search">Find packages</label><!--
+          --><button type="submit" id="search-submit" tabindex="1"><svg aria-hidden="aria-hidden" version="1.1" viewBox="0 0 1200 1200"><g transform="translate(0, 1200) scale(1, -1)"><path d="M500 1191q100 0 191 -39t156.5 -104.5t104.5 -156.5t39 -191l-1 -2l1 -5q0 -141 -78 -262l275 -274q23 -26 22.5 -44.5t-22.5 -42.5l-59 -58q-26 -20 -46.5 -20t-39.5 20l-275 274q-119 -77 -261 -77l-5 1l-2 -1q-100 0 -191 39t-156.5 104.5t-104.5 156.5t-39 191 t39 191t104.5 156.5t156.5 104.5t191 39zM500 1022q-88 0 -162 -43t-117 -117t-43 -162t43 -162t117 -117t162 -43t162 43t117 117t43 162t-43 162t-117 117t-162 43z"></path></g></svg></button>
+        </form>
+
         <p>
           To find documentation sets on HexDocs, you can go to the following URLs:
         </p>


### PR DESCRIPTION
This PR adds a simple search feature based on the `sitemap.xml` file.

The sitemap file is loaded on first search. Search results are displayed in page in a quite simple fashion. No extra information, apart from the name and a link to hex.pm, is shown.

Ordering of search results is based on the ordering used in the sitemap file.